### PR TITLE
Add autocomplete support

### DIFF
--- a/lua/core/autocmd.lua
+++ b/lua/core/autocmd.lua
@@ -63,3 +63,14 @@ vim.api.nvim_create_autocmd({ "CursorHold", "CursorHoldI" }, {
 		})
 	end
 })
+
+
+vim.api.nvim_create_autocmd("LspAttach", {
+	callback = function(ev)
+		local client = vim.lsp.get_client_by_id(ev.data.client_id)
+
+		if client:supports_method("textDocument/completion") then
+			vim.lsp.completion.enable(true, client.id, ev.buf, { autotrigger = true })
+		end
+	end,
+})

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -39,3 +39,11 @@ map("n", "<leader>f", vim.lsp.buf.format, bufopts)
 map("n", "[d", vim.diagnostic.goto_prev, bufopts)
 map("n", "]d", vim.diagnostic.goto_next, bufopts)
 map("n", "<leader>d", vim.diagnostic.open_float, bufopts)
+
+-- map <c-space> to activate completion
+map("i", "<c-space>", function() vim.lsp.completion.get() end)
+-- select with Enter
+map("i", "<cr>", "pumvisible() ? '<c-y>' : '<cr>'", { expr = true })
+-- navigation sugestions with Tab(next) and Shift + Tab(prev)
+map("i", "<Tab>", "pumvisible() ? '<C-n>' : '<Tab>'", { expr = true, noremap = true, silent = true })
+map("i", "<S-Tab>", "pumvisible() ? '<C-p>' : '<S-Tab>'", { expr = true, noremap = true, silent = true })

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -31,3 +31,5 @@ opt.completeopt = 'menu,menuone,noselect'
 
 opt.lazyredraw = true
 opt.hidden = true
+-- see `:h completeopt`
+opt.completeopt = "menuone,noselect,popup,fuzzy"


### PR DESCRIPTION
Enable LSP autocomplete with a popup menu, allowing selection with `<Enter>` and navigation with `<Tab>`.

- Tab: Next suggestion

- Shift + Tab: Previous suggestion
![menu_autocomplete](https://github.com/user-attachments/assets/aff7a792-f6fa-44df-a7bb-109134329004)

