### PR TITLE
feat: find and grep options 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ A clean, efficient Neovim configuration that leverages built-in features and pow
 > **Incomplete Setup**  
 > This configuration is not yet production-ready.  
 > • Pending LSP adjustments  
-> • Runtime path errors detected  
-
+> • Runtime path errors detected
 
 ## Features
 
@@ -35,8 +34,8 @@ A clean, efficient Neovim configuration that leverages built-in features and pow
 - [x] Useful autocommands
   - [x] Diagnostics float mouse hover
   - [x] autoformat
-- [ ] File finder 
-- [ ] Text search 
+- [x] File finder
+- [x] Text search
 
 ## Requirements
 
@@ -47,11 +46,13 @@ A clean, efficient Neovim configuration that leverages built-in features and pow
 ## Installation
 
 1. Backup your existing Neovim configuration:
+
 ```bash
 mv ~/.config/nvim ~/.config/nvim.backup
 ```
 
 3. Clone this repository:
+
 ```bash
 git clone https://github.com/yourusername/purevim.git ~/.config/nvim
 ```
@@ -75,4 +76,4 @@ MIT License - feel free to use and modify as you like.
 
 ---
 
-Made with love by a Neovim enthusiast 
+Made with love by a Neovim enthusiast

--- a/init.lua
+++ b/init.lua
@@ -1,9 +1,10 @@
 -- Main configuration Neovim
 -- Autor: Carlos
-package.path = package.path .. ';' .. vim.fn.stdpath('config') .. '/?.lua'
+package.path = package.path .. ";" .. vim.fn.stdpath("config") .. "/?.lua"
 
-require('core.options')
-require('core.keymaps')
-require('core.lsp').setup()
+require("core.options")
+require("core.keymaps")
+require("core.lsp").setup()
 require("core.autocmd")
 require("core.treesitter")
+require("core.search")

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -1,32 +1,62 @@
 local map = vim.keymap.set
-local search = require('core.search')
+local search = require("core.search")
 local bufopts = { noremap = true, silent = true }
 
-map('n', '<leader>ev', ':vsplit ~/.config/purevim<cr>')
+-- Quality of life
 
-map('n', '<C-h>', '<C-w>h')
-map('n', '<C-j>', '<C-w>j')
-map('n', '<C-k>', '<C-w>k')
+map("n", "<C-s>", ":w<CR>")
+map("n", "<Esc>", ":noh<CR>", {silent = true })
 
-map('n', '<C-l>', ':Exp<CR>')
+map("v", "J", ":m '>+1<CR>gv=gv")
+map("v", "K", ":m '<-2<CR>gv=gv")
 
-map('n', '<C-Up>', ':resize +2<CR>')
-map('n', '<C-Down>', ':resize -2<CR>')
-map('n', '<C-Left>', ':vertical resize -2<CR>')
-map('n', '<C-Right>', ':vertical resize +2<CR>')
+map("n", "<leader>e", ":Explore <CR>")
 
-map('n', '<S-l>', ':bnext<CR>')
-map('n', '<S-h>', ':bprevious<CR>')
-map('n', '<C-q>', ':bd<CR>')
+map("n", "<leader>ev", ":vsplit ~/.config/purevim<cr>")
 
--- map('n', '<C-p>', search.find_files)
--- map('n', '<leader>fg', search.grep)
+map("n", "<C-h>", "<C-w>h")
+map("n", "<C-j>", "<C-w>j")
+map("n", "<C-k>", "<C-w>k")
+map("n", "<C-l>", "<C-w>l")
 
-map('n', '<C-s>', ':w<CR>')
-map('n', '<Esc>', ':noh<CR>')
+map("n", "<C-Up>", ":resize +2<CR>")
+map("n", "<C-Down>", ":resize -2<CR>")
+map("n", "<C-Left>", ":vertical resize -2<CR>")
+map("n", "<C-Right>", ":vertical resize +2<CR>")
 
-map('v', 'J', ":m '>+1<CR>gv=gv")
-map('v', 'K', ":m '<-2<CR>gv=gv")
+map("n", "<S-l>", ":bnext<CR>")
+map("n", "<S-h>", ":bprevious<CR>")
+map("n", "<C-q>", ":bd<CR>")
+
+map("n", "<leader>q", ":copen <CR>")
+map("n", "]q", ":cnext<CR>", { silent = true })
+map("n", "[q", ":cprev<CR>", { silent = true })
+
+map("n", "[d", function()
+	vim.diagnostic.jump({ count = -1, float = true })
+end)
+map("n", "]d", function()
+	vim.diagnostic.jump({ count = 1, float = true })
+end)
+
+
+-- Search (find and grep)
+local map = vim.keymap.set
+map("n", "<leader>ff", ":find ")
+map("n", "<leader>vv", ":vert sf ")
+map("n", "<leader>b", ":b ")
+map("n", "<leader>fq", ":Findqf ")
+map("n", "<leader>g", ":grep ''<left>")
+map("n", "<leader>G", ":grep <C-R><C-W><CR>")
+map("n", "<leader>z", ":Zgrep ")
+map("n", "<leader>Z", ":Fzfgrep ")
+map("n", "<leader>cf", ":Cfilter ")
+map("n", "<leader>cz", ":Cfuzzy ")
+vim.keymap.set("c", "<C-Space>", ".*", { noremap = true })
+vim.keymap.set("c", "<A-9>", "\\(", { noremap = true })
+vim.keymap.set("c", "<A-0>", "\\)", { noremap = true })
+vim.keymap.set("c", "<A-Space>", "\\<space>", { noremap = true })
+
 
 -- LSP
 map("n", "gd", vim.lsp.buf.definition, bufopts)
@@ -35,13 +65,13 @@ map("n", "gi", vim.lsp.buf.implementation, bufopts)
 map("n", "gr", vim.lsp.buf.references, bufopts)
 map("n", "<leader>rn", vim.lsp.buf.rename, bufopts)
 map("n", "<leader>ca", vim.lsp.buf.code_action, bufopts)
-map("n", "<leader>f", vim.lsp.buf.format, bufopts)
-map("n", "[d", vim.diagnostic.goto_prev, bufopts)
-map("n", "]d", vim.diagnostic.goto_next, bufopts)
+map("n", "<leader>mp", vim.lsp.buf.format, bufopts)
 map("n", "<leader>d", vim.diagnostic.open_float, bufopts)
 
 -- map <c-space> to activate completion
-map("i", "<c-space>", function() vim.lsp.completion.get() end)
+map("i", "<c-space>", function()
+	vim.lsp.completion.get()
+end)
 -- select with Enter
 map("i", "<cr>", "pumvisible() ? '<c-y>' : '<cr>'", { expr = true })
 -- navigation sugestions with Tab(next) and Shift + Tab(prev)

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -33,3 +33,14 @@ opt.lazyredraw = true
 opt.hidden = true
 -- see `:h completeopt`
 opt.completeopt = "menuone,noselect,popup,fuzzy"
+
+
+vim.opt.shortmess:append("I")
+
+vim.cmd([[
+  hi Normal guibg=NONE ctermbg=NONE
+  hi NormalNC guibg=NONE ctermbg=NONE
+  hi SignColumn guibg=NONE ctermbg=NONE
+  hi LineNr guibg=NONE ctermbg=NONE
+  hi EndOfBuffer guibg=NONE ctermbg=NONE
+]])

--- a/lua/core/search.lua
+++ b/lua/core/search.lua
@@ -1,11 +1,90 @@
+-- lua/core/search.lua
+--
+-- File finding and grepping helpers (fd, rg, fzf, quickfix)
+--
+-- SOURCE: https://jkrl.me/vim/2025/09/03/nvim-fuzzy-grep.html
+
+-- Load cfilter (shipped with Neovim)
+vim.cmd.packadd("cfilter")
+
+-- Settings
+vim.opt.wildmenu = true
+vim.opt.wildmode = { "noselect:longest:lastused", "full" }
+vim.opt.wildoptions = "pum"
+vim.opt.path:append("**")
+vim.opt.grepprg = "rg --vimgrep --hidden -g '!.git/*'"
+
+vim.opt.wildignorecase = true
+vim.opt.wildignore:append({ "*/node_modules/*", "*/.git/*" })
+
+-- Functions
 local M = {}
 
--- TODO: Implement find files
-function M.find_files()
+function M.fuzzy_filter_qf(...)
+	local args = { ... }
+	local query = table.concat(args, " ")
+	vim.fn.setqflist(vim.fn.matchfuzzy(vim.fn.getqflist(), query, { key = "text" }))
 end
 
--- TODO: Implement search grep word files
-function M.grep()
+function M.fuzzy_filter_grep(query, path)
+	path = path or "."
+	vim.cmd("grep! '" .. query .. "' " .. path)
+	local sort_query = query:gsub("%.%*", ""):gsub("\\%(.)", "%1")
+	M.fuzzy_filter_qf(sort_query)
+	vim.cmd("cfirst")
+	vim.cmd("copen")
 end
+
+function M.fzf_grep(query, path)
+	path = path or "."
+	local oldgrepprg = vim.o.grepprg
+	vim.o.grepprg = "rg --column --hidden -g '!.git/*' . " .. path .. " | fzf --filter='$*' --delimiter : --nth 4.."
+	vim.cmd("grep " .. query)
+	vim.o.grepprg = oldgrepprg
+end
+
+function M.fuzzy_find_func(cmdarg, _)
+	return vim.fn.systemlist("fd --hidden . | fzf --filter='" .. cmdarg .. "'")
+end
+
+function M.fd_set_quickfix(...)
+	local args = { ... }
+	local fdresults = vim.fn.systemlist("fd -t f --hidden " .. table.concat(args, " "))
+	if vim.v.shell_error ~= 0 then
+		vim.api.nvim_err_writeln("Fd error: " .. fdresults[1])
+		return
+	end
+	local qf = {}
+	for _, val in ipairs(fdresults) do
+		table.insert(qf, { filename = val, lnum = 1, text = val })
+	end
+	vim.fn.setqflist(qf)
+	vim.cmd("copen")
+end
+
+-- Commands
+vim.api.nvim_create_user_command("Findqf", function(opts)
+	M.fd_set_quickfix(unpack(opts.fargs))
+end, { nargs = "+", complete = "file_in_path" })
+
+vim.api.nvim_create_user_command("Cfuzzy", function(opts)
+	M.fuzzy_filter_qf(unpack(opts.fargs))
+end, { nargs = 1 })
+
+vim.api.nvim_create_user_command("Zgrep", function(opts)
+	M.fuzzy_filter_grep(unpack(opts.fargs))
+end, { nargs = "+", complete = "file_in_path" })
+
+vim.api.nvim_create_user_command("Fzfgrep", function(opts)
+	M.fzf_grep(unpack(opts.fargs))
+end, { nargs = "+", complete = "file_in_path" })
+
+vim.cmd([[
+function! FuzzyFindFunc(cmdarg, cmdline, cursorpos)
+  " Use echom to log in :messages
+  echom "FuzzyFindFunc called with: " . a:cmdarg
+  return luaeval("require'core.search'.fuzzy_find_func(_A[1])", [a:cmdarg])
+endfunction
+]])
 
 return M


### PR DESCRIPTION
Add grep bindings: <leader>g and friends
Add find bindings: <leader>ff and friends (tab tab completes)
Add change buffer binding: <leader>b (tab tab completes with all open buffers)

Makes C-w -> h, j, k AND L behave

Change explorer bindings: <leader>e

Update deprecated bindings to [d ]d
Add quickfix bindings: <leader>q [q ]q

Make :noh silent.

Formats lua to keep stuff consistent (" is preferred over ')
 
See if you like it :) I have no idea if the :find stuff is working alright, it looks like it, but we may fix it later.

Quick testing:
<leader>ff lua<tab>
<leader>ee
<leader>g lua
<leader>b<tab>

More options are available.
