### PR TITLE
feat: enable experimental _extui option if available

### DIFF
--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -48,3 +48,11 @@ vim.cmd([[
   hi LineNr guibg=NONE ctermbg=NONE
   hi EndOfBuffer guibg=NONE ctermbg=NONE
 ]])
+
+
+local ok, extui = pcall(require, "vim._extui")
+if ok then
+  extui.enable({
+    enable = true,
+  })
+end


### PR DESCRIPTION
As documented on https://neovim.io/doc/user/lua.html#vim._extui.

Gives us a better UI for :reg :marks :mes...

It does not block the UI, you can quickly revisit and jump into the buffer with g< currently available on 0.12

newer tui (left) / old one (right):

<img width="1728" height="333" alt="Captura de Tela 2025-09-18 às 22 29 06" src="https://github.com/user-attachments/assets/798bac35-ce43-47f0-9951-47fa6b61fbdd" />
<img width="1728" height="426" alt="Captura de Tela 2025-09-18 às 22 29 56" src="https://github.com/user-attachments/assets/4621fab5-4e27-44a5-94d3-d657190b8af0" />
