### PR TITLE
feat: configurable fzf window

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
         buildInputs = with pkgs; [
           usql
           lazygit
+					bat
           # Neovim itself
           neovim
 

--- a/init.lua
+++ b/init.lua
@@ -43,7 +43,12 @@ run_if("lazygit", function()
 	require("core.integrations.lazygit")
 end)
 run_if("fzf", function()
-	require("core.integrations.fzf")
+	require("core.integrations.fzf").setup({
+		position = "bottom",
+		width_ratio = 1,
+		height_ratio = 0.3,
+		border = "none"
+	})
 end)
 run_if("statusline", function()
 	require("core.statusline")

--- a/lua/core/integrations/fzf.lua
+++ b/lua/core/integrations/fzf.lua
@@ -9,11 +9,31 @@ local function project_root()
 	end
 end
 
+M.config = {
+  position = "bottom", -- "center" | "bottom" | "top"
+  width_ratio = 0.8,
+  height_ratio = 0.8,
+  border = "rounded" -- "none" | "rounded" | "single" etc.
+}
+
+M.setup = function(opts)
+  M.config = vim.tbl_deep_extend("force", M.config, opts or {})
+end
+
 M.fzf_open = function()
-	local width = math.floor(vim.o.columns * 0.8)
-	local height = math.floor(vim.o.lines * 0.8)
-	local row = math.floor((vim.o.lines - height) / 2)
-	local col = math.floor((vim.o.columns - width) / 2)
+  local cfg = M.config
+  local width =  math.floor(vim.o.columns * cfg.width_ratio)
+  local height = math.floor(vim.o.lines * cfg.height_ratio)
+  local col = math.floor((vim.o.columns - width) / 2)
+
+  local row
+  if cfg.position == "center" then
+    row = math.floor((vim.o.lines - height) / 2)
+  elseif cfg.position == "top" then
+    row = 1
+  else
+    row = vim.o.lines - height - 2
+  end
 
 	local buf = vim.api.nvim_create_buf(false, true)
 
@@ -24,6 +44,7 @@ M.fzf_open = function()
 		row = row,
 		col = col,
 		style = "minimal",
+		border = cfg.border,
 	})
 
 	local root = project_root()


### PR DESCRIPTION
This PR introduces a configurable layout system for the FZF integration, allowing users to control position, size, and border style through setup options.

- Added support for the following configuration options:
  - position: "center" | "bottom" | "top"
  - width_ratio: window width as a percentage of total columns
  - height_ratio: window height as a percentage of total lines
  - border: border style ("none", "rounded", "single", etc.)

- Updated M.fzf_open to dynamically calculate position based on configuration.
- Added a setup method to merge user-supplied options with defaults.
- Default behavior remains centered 0.8x0.8 with "rounded" border.

