### PR TITLE
feat: refactor feature toggles to use `vim.g.purevim_features`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 early_init.lua
-private.lua
 post_init.lua
 
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ powerful external tools for a great editing experience.
 
 <img width="1912" height="1017" alt="image" src="https://github.com/user-attachments/assets/dc70f57b-cd79-42ae-87ef-21a07ca8c118" />
 
-
 ## Performance
 
 This configuration is designed to be lightweight and fast:
@@ -90,7 +89,9 @@ a shell with Neovim and all the pre-configured language servers
 (`rust-analyzer`, `lua-language-server`, `typescript-language-server`)
 available in your `PATH`.
 
-```bash cd ~/.config/nvim nix develop ```
+```bash
+cd ~/.config/nvim && nix develop
+```
 
 Now, you can run `nvim` from within this shell, and everything will work out of
 the box.
@@ -102,23 +103,24 @@ setup and dependency checks for you.
 
 Run the installer:
 
-```bash 
+```bash
 curl -fsSL https://raw.githubusercontent.com/carl0xs/purevim/master/bin/purevim | bash
 ```
+
 The script will:
 
 - Back up your existing Neovim configuration (if any) to ~/.config/nvim.backup
 - Clone this repository to ~/.config/nvim
 - Check for the required dependencies and alert you if something is missing
 - Dependencies checked by the script:
-   - nvim
-   - lazygit
-   - rg (ripgrep)
-   - fzf
-   - lua-language-server
-   - rust-analyzer
-   - typescript-language-server
-   - bat
+  - nvim
+  - lazygit
+  - rg (ripgrep)
+  - fzf
+  - lua-language-server
+  - rust-analyzer
+  - typescript-language-server
+  - bat
 
 ### 3. Manual Installation
 
@@ -143,7 +145,7 @@ Then manually ensure all dependencies are installed on your system:
 
 Once everything is ready, just launch Neovim:
 
-```bash 
+```bash
 nvim
 ```
 
@@ -158,13 +160,14 @@ customize behavior without modifying the main config. All these files are
 If you'd like to customize **PureVim**, simply create these files in the same
 folder as this config `init.lua`.
 
-1. **`early_init.lua`** → runs first, can set globals or feature toggles.
+1. **`early_init.lua`** → runs first, can set globals or feature toggles. Users
+   **SHOULD** customize this file.
 
-2. **Core config + optional `private.lua`** → loads modules conditionally based
-on feature toggles.
+2. **`init.lua`** → loads modules conditionally based on feature toggles. User
+   should **NOT** edit this file.
 
 3. **`post_init.lua`** → runs last, for final tweaks and personal
-customization.
+   customization. Users **SHOULD** customize this file.
 
 > ⚡ If a file does not exist, it is simply skipped, and the config runs
 > normally.
@@ -174,7 +177,7 @@ customization.
 - **Purpose:** Runs **before the main config**.
 
 - **Use it for:** Setting global options, overriding defaults, changing leader
-keys, or defining feature toggles.
+  keys, or defining feature toggles.
 
 - **Example:**
 
@@ -185,32 +188,42 @@ vim.g.purevim_colorscheme = "gruvbox"
 ```
 
 > [!NOTE]
+>
 > ### Colorschemes
-> PureVim comes with two built-in colorschemes:
+>
+> PureVim comes with extra colorschemes:
+>
 > - `catppuccin` (the default)
 > - `gruvbox`
 
-### 2. `private.lua`
+You can also turn `PureVim` special features on/off, or even customize its
+setup. Just comment/uncomment what you need!
 
-- **Purpose:** Optional feature toggle file, loaded by the main config.
-- **Use it for:** Turning specific features ON or OFF.
-- **Default behavior:** All features run if this file does not exist.
-- **Example:**
-
-```lua -- ~/.config/nvim/private.lua
-
-return {
-  lsp = false, -- disable LSP
-  treesitter = true, -- enable treesitter
-  colorscheme = false, -- disable custom pure vim colorscheme
+```lua
+vim.g.purevim_features = {
+	-- colorscheme = false, -- disable colorscheme
+	-- dashboard = false, -- disable dashboard
+	-- fzf = { -- configure FZF or set to false to disable
+	-- 	position = "bottom",
+	-- 	width_ratio = 1,
+	-- 	height_ratio = 0.3,
+	-- 	border = "none",
+	-- },
+	-- lsp = false, -- disable LSP
+	-- lazygit = false, -- disable lazygit
 }
 ```
+
+### 2. `init.lua`
+
+This file orchestrates how everything is loaded with `PureVim`. **DO NOT** use
+this to add your own configs. Instead use `early_init.lua` or `post_init.lua`.
 
 ### 3. `post_init.lua`
 
 - **Purpose:** Runs **after all core modules** have loaded.
 - **Use it for:** Adding personal keymaps, tweaks, custom autocommands, or
-modifying highlights after the colorscheme.
+  modifying highlights after the colorscheme.
 - **Example:**
 
 ```lua -- ~/.config/nvim/post_init.lua
@@ -246,9 +259,9 @@ Here are some folding key hints:
 
 Focus the buffer you'd like more info to and run the command:
 
-``` 
+```
 :PureCheckTreesitter
- ```
+```
 
 ## License
 

--- a/early_init.lua
+++ b/early_init.lua
@@ -1,0 +1,22 @@
+-- ~/.config/nvim/user_pre.lua
+-- Gitignored
+
+-- Example: change leader key before loading keymaps
+vim.g.mapleader = " "
+
+-- Example: change the default colorscheme (see "Colorschemes" section below)
+-- vim.g.purevim_colorscheme = "gruvbox"
+
+-- Example: Feature toggles (users can set these in early_init.lua)
+vim.g.purevim_features = {
+	-- colorscheme = false, -- disable colorscheme
+	-- dashboard = false, -- disable dashboard
+	-- fzf = { -- configure FZF or set to false to disable
+	-- 	position = "bottom",
+	-- 	width_ratio = 1,
+	-- 	height_ratio = 0.3,
+	-- 	border = "none",
+	-- },
+	-- lsp = false, -- disable LSP
+	-- lazygit = false, -- disable lazygit
+}

--- a/init.lua
+++ b/init.lua
@@ -8,19 +8,16 @@ package.path = package.path .. ";" .. vim.fn.stdpath("config") .. "/?.lua"
 -- Load optional early_init.lua file
 pcall(require, "early_init")
 
-
--- Try to load private feature toggles
-local ok, private = pcall(require, "private")
-if not ok then
-	private = {} -- default: everything enabled
-end
+-- Feature toggles (users can set these in early_init.lua)
+local features = vim.g.purevim_features or {}
 
 -- Helper to conditionally run modules
-local function run_if(feature, fn)
-	if private[feature] == false then
+local function run_if_feat_enabled(feature, fn)
+	local conf = features[feature]
+	if conf == false then
 		return
 	end
-	fn()
+	fn(conf) -- pass feature configuration if available
 end
 
 -- Core modules
@@ -29,39 +26,46 @@ require("core.keymaps")
 require("core.integrations.git").setup()
 
 -- Optional modules
-run_if("lsp", function()
+run_if_feat_enabled("lsp", function()
 	require("core.lsp").setup()
 end)
-run_if("autocmd", function()
+
+run_if_feat_enabled("autocmd", function()
 	require("core.autocmd")
 end)
-run_if("treesitter", function()
+
+run_if_feat_enabled("treesitter", function()
 	require("core.treesitter")
 end)
-run_if("search", function()
+
+run_if_feat_enabled("search", function()
 	require("core.search")
 end)
-run_if("lazygit", function()
+
+run_if_feat_enabled("lazygit", function()
 	require("core.integrations.lazygit")
 end)
-run_if("fzf", function()
-	require("core.integrations.fzf").setup({
-		position = "bottom",
-		width_ratio = 1,
-		height_ratio = 0.3,
-		border = "none"
-	})
+
+run_if_feat_enabled("fzf", function(opts)
+	opts = opts or {}
+	require("core.integrations.fzf").setup(opts)
 end)
-run_if("statusline", function()
+
+run_if_feat_enabled("statusline", function()
 	require("core.statusline")
 end)
-run_if("colorscheme", function()
+
+run_if_feat_enabled("colorscheme", function()
 	require("core.colorscheme").setup()
 end)
-run_if("usql", function()
+
+run_if_feat_enabled("usql", function()
 	require("core.integrations.usql")
 end)
-require('core.dashboard').setup()
+
+run_if_feat_enabled("dashboard", function()
+	require("core.dashboard").setup()
+end)
 
 -- Load optional post_init.lua file
 pcall(require, "post_init")


### PR DESCRIPTION
* Removed legacy `private.lua` system in favor of a centralized `vim.g.purevim_features` table.
* Added support for toggleable modules: LSP, LazyGit, Colorscheme, FZF, Dashboard, Treesitter, Statusline, USQL, Search, Autocmd.
* FZF and Dashboard now accept user-defined configuration options via the feature table.
* Updated `README.md` with examples and guidance for customizing features in `early_init.lua`.
* Commented examples make it easy for users to enable/disable features without editing core files.
* `early_init.lua` and `post_init.lua` remain the recommended places for user customization.

Notes:

* Default behavior: features are enabled unless explicitly set to `false`.
* Backward compatibility: none (users of `private.lua` should migrate to `vim.g.purevim_features`).

This should fix #29, #28 and help on how to make #26 and other user configured features available on the near future.