### PR TITLE
Fix typo opts parameter git signs

### DIFF
--- a/lua/core/integrations/git.lua
+++ b/lua/core/integrations/git.lua
@@ -24,7 +24,7 @@ local function setup_signs(opts)
   opts = vim.tbl_deep_extend("force", defaults, opts or {})
 
   vim.fn.sign_define("GitSignsAdd", { text = opts.staged.add, texthl = "GitSignsAdd" })
-  vim.fn.sign_define("GitSignsChange", { text = opts.staged.changes, texthl = "GitSignsChange" })
+  vim.fn.sign_define("GitSignsChange", { text = opts.staged.change, texthl = "GitSignsChange" })
   vim.fn.sign_define("GitSignsDelete", { text = opts.staged.delete, texthl = "GitSignsDelete" })
 end
 


### PR DESCRIPTION
This commit fix TYPO parameter `change` in git signs. 

Reported issue #25 

close #25 